### PR TITLE
MAINT: Basics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+# Upload a Python Package using Twine when a release is created
+
+name: Build
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    - name: Build package
+      run: python -m build --sdist --wheel
+    - name: Check package
+      run: twine check --strict dist/*
+    - name: Check env vars
+      run: |
+        echo "Triggered by: ${{ github.event_name }}"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist
+
+  # PyPI on release
+  pypi:
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,22 @@
+name: Style
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+on: [push, pull_request]
+
+jobs:
+  check-style:
+    name: Ruff codespell black
+    runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - name: Install ruff and codespell
+      run: pip install ruff codespell tomli
+    - run: make ruff
+    - run: make codespell-error
+    - uses: psf/black@stable

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,64 @@
+name: test_suite
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+  create:
+    branches: [main]
+    tags: ['**']
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.11"]  # Oldest and newest supported versions
+        mne-version: [mne-stable]
+
+        include:
+          # Only test devel versions with Python 3.10
+          - os: ubuntu-latest
+            python-version: "3.10"
+            mne-version: mne-main
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Python dependencies using pip
+      run: python -m pip install --upgrade pip setuptools_scm setuptools
+    - name: Install MNE (stable)
+      if: "matrix.mne-version == 'mne-stable'"
+      run: pip install git+https://github.com/mne-tools/mne-python.git@maint/1.3
+    - name: Install MNE (main)
+      if: "matrix.mne-version == 'mne-main'"
+      run: pip install git+https://github.com/mne-tools/mne-python.git@main
+    - run: mne sys_info
+    - run: pip install -ve .[tests]
+    - run: python -c "import mne_gui_addons; print(mne_gui_addons.__version__)"
+    - run: ./tools/get_testing_version.sh
+      working-directory: mne-python
+      shell: bash
+      name: 'Get testing version'
+    - uses: actions/cache@v3
+      with:
+        key: ${{ env.TESTING_VERSION }}
+        path: ~/mne_data
+      name: 'Cache testing data'
+    - run: ./tools/github_actions_download.sh
+      shell: bash
+      working-directory: mne-python
+    - name: Run pytest
+      run: pytest mne_gui_addons
+    - name: Upload coverage stats to codecov
+      uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Other
+junit-results.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+# Eventually we should use yamllint, too
+files: ^(.*\.(py|yaml))$
+exclude: ^(\.[^/]*cache/.*)$
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        args:
+          - --safe
+          - --quiet
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.178
+    hooks:
+      - id: ruff
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# mne-gui-addons
-MNE-Python GUI addons

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,4 @@
+MNE-GUI-Addons
+--------------
+
+MNE-Python GUI addons.

--- a/mne_gui_addons/__init__.py
+++ b/mne_gui_addons/__init__.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("mne_gui_addons")
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "mne-gui-addons"
+description = "MNE-Python GUI addons."
+readme = "README.rst"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+keywords = ["science", "neuroscience", "psychology"]
+authors = [
+  {name = "Alex Rockhill", email = "aprockhill206@gmail.com"},
+  {name = "Eric Larson"},
+]
+classifiers = [
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python"
+]
+dependencies = [
+    "packaging",
+    "qtpy",
+    "pyvista",
+    "pyvistaqt",
+    "mne",
+    "setuptools >=65",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+tests = [
+    "pytest",
+    "pytest-cov",
+    "pytest-qt",
+    "black",  # function signature formatting
+]
+
+[project.urls]
+homepage = "https://github.com/mne-tools/mne-gui-addons"
+repository = "https://github.com/mne-tools/mne-gui-addons"
+changelog = "https://github.com/mne-tools/mne-gui-addons/releases"
+
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+tag_regex = "^(?P<prefix>v)?(?P<version>[0-9.]+)(?P<suffix>.*)?$"
+version_scheme = "release-branch-semver"
+
+[tool.setuptools.packages.find]
+exclude = ["false"]  # on CircleCI this folder appears during pip install -ve. for an unknown reason
+
+[tool.codespell]
+skip = "docs/site/*,*.html,steps/freesurfer/contrib/*"
+ignore-words = "ignore_words.txt"
+builtin = "clear,rare,informal,names,usage"
+quiet-level = 3
+interactive = 3
+enable-colors = ""
+count = ""
+
+[tool.pytest.ini_options]
+addopts = "-ra -vv --tb=short --cov=mne_gui_addons --cov-report= --junit-xml=junit-results.xml --durations=10"
+testpaths = [
+    "mne_gui_addons",
+]
+junit_family = "xunit2"
+
+[tool.ruff]
+exclude = ["dist/" , "build/"]
+
+[tool.black]
+exclude = "(dist/)|(build/)"


### PR DESCRIPTION
1. `pyproject.toml`-based install using `setuptools_scm` adapted from `mne-bids-pipeline`
2. style and release actions adapted from `mne-bids-pipeline`
3. pytest adapted from `mne-bids`

No CircleCI doc build for now since I don't think we need it / can use MNE-Python for it (maybe?).

Once this is green I'll set up branch protections for the actions and merge rules (squash+merge only, use PR title), then it's on to actually moving code over!