### PR TITLE
[ENH, MRG] Add group average

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
         - run:
             name: Get data
             command: |
-              python -c "import mne; mne.datasets.somato.data_path(update_path=True, verbose=True)"
+              python -c "import mne; mne.datasets.somato.data_path(update_path=True, verbose=True); mne.datasets.misc.data_path(update_path=True, verbose=True);"
               ls -al ~/mne_data;
         - run:
             name: make html
@@ -86,6 +86,10 @@ jobs:
             key: data-cache-somato
             paths:
               - ~/mne_data/MNE-somato-data
+        - save_cache:
+            key: data-cache-misc
+            paths:
+              - ~/mne_data/MNE-misc-data
 
     deploy:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
         - run:
             name: Get Python running
             command: |
-              pip install --upgrade PyQt6 sphinx-gallery pydata-sphinx-theme sphinxcontrib-bibtex numpydoc scikit-learn autoreject git+https://github.com/pyvista/pyvista@main memory_profiler
+              pip install --upgrade PyQt6 sphinx-gallery pydata-sphinx-theme numpydoc scikit-learn nilearn autoreject git+https://github.com/pyvista/pyvista@main memory_profiler sphinxcontrib.bibtex sphinxcontrib.youtube
               pip install -ve ./mne-python .
         - run:
             name: Check Qt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
         - run:
             name: Get Python running
             command: |
-              pip install --upgrade PyQt6 sphinx-gallery pydata-sphinx-theme numpydoc scikit-learn autoreject git+https://github.com/pyvista/pyvista@main memory_profiler
+              pip install --upgrade PyQt6 sphinx-gallery pydata-sphinx-theme sphinxcontrib-bibtex numpydoc scikit-learn autoreject git+https://github.com/pyvista/pyvista@main memory_profiler
               pip install -ve ./mne-python .
         - run:
             name: Check Qt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
         - run:
             name: Get Python running
             command: |
-              pip install --upgrade PyQt6 sphinx-gallery pydata-sphinx-theme numpydoc scikit-learn nilearn git+https://github.com/pyvista/pyvista@main memory_profiler sphinxcontrib.bibtex sphinxcontrib.youtube
+              pip install --upgrade PyQt6 sphinx-gallery pydata-sphinx-theme numpydoc scikit-learn autoreject git+https://github.com/pyvista/pyvista@main memory_profiler
               pip install -ve ./mne-python .
         - run:
             name: Check Qt
@@ -61,11 +61,10 @@ jobs:
         - restore_cache:
             keys:
               - data-cache-somato
-              - data-cache-misc
         - run:
             name: Get data
             command: |
-              python -c "import mne; mne.datasets.somato.data_path(update_path=True, verbose=True); mne.datasets.misc.data_path(update_path=True, verbose=True);"
+              python -c "import mne; mne.datasets.somato.data_path(update_path=True, verbose=True)"
               ls -al ~/mne_data;
         - run:
             name: make html
@@ -87,10 +86,6 @@ jobs:
             key: data-cache-somato
             paths:
               - ~/mne_data/MNE-somato-data
-        - save_cache:
-            key: data-cache-misc
-            paths:
-              - ~/mne_data/MNE-misc-data
 
     deploy:
       machine:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 import pyvista
-import mne
 import mne_gui_addons
 
 faulthandler.enable()
@@ -108,7 +107,7 @@ sphinx_gallery_conf = {
     "remove_config_comments": True,
     "min_reported_time": 1.0,
     "abort_on_example_error": False,
-    "image_scrapers": ("matplotlib", mne.gui._GUIScraper(), "pyvista"),
+    "image_scrapers": ("matplotlib", mne_gui_addons._GUIScraper(), "pyvista"),
     "show_memory": not sys.platform.startswith(("win", "darwin")),
     "line_numbers": False,  # messes with style
     "capture_repr": ("_repr_html_",),

--- a/examples/ieeg_locate.py
+++ b/examples/ieeg_locate.py
@@ -41,6 +41,7 @@ import nilearn.plotting
 from dipy.align import resample
 
 import mne
+import mne_gui_addons as mne_gui
 from mne.datasets import fetch_fsaverage
 
 # paths to mne datasets: sample sEEG and FreeSurfer's fsaverage subject,
@@ -374,7 +375,7 @@ raw = mne.io.read_raw(misc_path / "seeg" / "sample_seeg_ieeg.fif")
 # you may want to add `block=True` to halt execution until you have interacted
 # with the GUI to find the channel positions, that way the raw object can
 # be used later in the script (e.g. saved with channel positions)
-mne.gui.locate_ieeg(
+mne_gui.locate_ieeg(
     raw.info,
     subj_trans,
     CT_aligned,
@@ -406,7 +407,7 @@ CT_aligned_ecog = mne.transforms.apply_volume_registration(
 raw_ecog = mne.io.read_raw(misc_path / "ecog" / "sample_ecog_ieeg.fif")
 # use estimated `trans` which was used when the locations were found previously
 subj_trans_ecog = mne.coreg.estimate_head_mri_t("sample_ecog", misc_path / "ecog")
-mne.gui.locate_ieeg(
+mne_gui.locate_ieeg(
     raw_ecog.info,
     subj_trans_ecog,
     CT_aligned_ecog,

--- a/examples/locate_ieeg_micro.py
+++ b/examples/locate_ieeg_micro.py
@@ -19,6 +19,7 @@ shows how to do this.
 import numpy as np
 import nibabel as nib
 import mne
+import mne_gui_addons as mne_gui
 
 # path to sample sEEG
 misc_path = mne.datasets.misc.data_path()
@@ -57,7 +58,7 @@ head_ct_t = mne.transforms.invert_transform(mne.channels.compute_native_head_t(m
 # launch the viewer with only the CT (note, we won't be able to use
 # the MR in this case to help determine which brain area the contact is
 # in), and use the user interface to find the locations of the contacts
-gui = mne.gui.locate_ieeg(raw.info, head_ct_t, CT_orig)
+gui = mne_gui.locate_ieeg(raw.info, head_ct_t, CT_orig)
 
 # we'll programmatically mark all the contacts on one electrode shaft
 for i, pos in enumerate(

--- a/examples/volume_stc_group_study.py
+++ b/examples/volume_stc_group_study.py
@@ -75,6 +75,7 @@ for sub in range(1, 4):
         baseline=None,
         preload=True,
     )
+    del raw
     epochs.set_eeg_reference(projection=True)
 
     # reject bad epochs
@@ -91,7 +92,7 @@ for sub in range(1, 4):
 
     # make forward model
     fwd = mne.make_forward_solution(
-        raw.info, trans=trans, src=src, bem=bem, eeg=True, mindist=5.0
+        epochs.info, trans=trans, src=src, bem=bem, eeg=True, mindist=5.0
     )
 
     rank = mne.compute_rank(epochs, tol=1e-6, tol_kind="relative")
@@ -182,14 +183,15 @@ viewer = mne_gui.view_vol_stc(
 viewer.go_to_extreme()  # show the maximum intensity source vertex
 viewer.set_cmap(vmin=0.25, vmid=0.8)
 viewer.set_3d_view(azimuth=40, elevation=35, distance=300)
+del stcs_epochs, insts_epochs
 
 # %%
-# Use the viewer to explore the time-frequency source estimates, specifically
-# inter-trial coherence (itc).
+# Use the viewer to explore the time-frequency source estimates, we'll
+# use the power in this case but you can also view inter-trial coherence (itc).
 
 viewer = mne_gui.view_vol_stc(
     stcs_tfr,
-    group="itc",
+    group="power",  # can also be "itc"
     subject=template,
     subjects_dir=subjects_dir,
     src=src,
@@ -200,3 +202,4 @@ viewer = mne_gui.view_vol_stc(
 viewer.go_to_extreme()  # show the maximum intensity source vertex
 viewer.set_cmap(vmin=0.25, vmid=0.8)
 viewer.set_3d_view(azimuth=40, elevation=35, distance=300)
+del stcs_tfr, insts_tfr

--- a/examples/volume_stc_group_study.py
+++ b/examples/volume_stc_group_study.py
@@ -1,0 +1,154 @@
+"""
+.. _ex-ieeg-micro:
+
+====================================================
+Volume Source Time Course Estimate for a Group Study
+====================================================
+
+
+"""
+
+# Authors: Alex Rockhill <aprockhill@mailbox.org>
+#
+# License: BSD-3-Clause
+
+import os.path as op
+import numpy as np
+import mne
+import mne_gui_addons as mne_gui
+import autoreject
+from mne.time_frequency import csd_tfr
+
+fs_dir = mne.datasets.fetch_fsaverage(verbose=True)
+subjects_dir = op.dirname(fs_dir)
+
+template = 'fsaverage'
+trans = 'fsaverage'  # MNE has a built-in fsaverage transformation
+src = mne.read_source_spaces(
+    op.join(fs_dir, 'bem', 'fsaverage-vol-5-src.fif'))
+bem = mne.read_bem_solution(
+    op.join(fs_dir, 'bem', 'fsaverage-5120-5120-5120-bem-sol.fif'))
+
+# basic task parameters
+tmin, tmax = -1., 4.
+active_win = (0, 4)
+baseline_win = (-1, 0)
+event_id = dict(hands=2, feet=3)
+runs = [6, 10, 14]  # motor imagery: hands vs feet
+
+# %%
+# Compute source time course (stc) estimates for both time courses
+# and spectrograms (time-frequency).
+
+montage = mne.channels.make_standard_montage('standard_1005')
+stcs_tfr = list()
+stcs_epochs = list()
+insts_tfr = list()
+insts_epochs = list()
+for sub in range(1, 4):
+    print(f'Computing source estimate for subject {sub}')
+    raw_fnames = mne.datasets.eegbci.load_data(subject=sub, runs=runs)
+    raw = mne.concatenate_raws([
+        mne.io.read_raw(raw_fname, preload=True, verbose=False)
+        for raw_fname in raw_fnames])
+    mne.datasets.eegbci.standardize(raw)  # set channel names
+    raw.set_montage(montage, verbose=False)
+
+    # make epochs
+    events, _ = mne.events_from_annotations(raw, event_id=dict(T1=2, T2=3))
+
+    picks = mne.pick_types(raw.info, meg=False, eeg=True, stim=False,
+                           eog=False, exclude='bads')
+    epochs = mne.Epochs(raw, events, event_id, tmin - 0.5, tmax + 0.5,
+                        proj=True, picks=picks, baseline=None, preload=True)
+    epochs.set_eeg_reference(projection=True)
+
+    # reject bad epochs
+    reject = autoreject.get_rejection_threshold(epochs)
+    epochs.drop_bad(reject=reject)
+
+    epochs.filter(l_freq=1, h_freq=None)
+    ica = mne.preprocessing.ICA(n_components=15, random_state=11)
+    ica.fit(epochs)
+
+    eog_idx, scores = ica.find_bads_eog(epochs, ch_name='Fp1')
+    muscle_idx, scores = ica.find_bads_muscle(epochs)
+    ica.apply(epochs, exclude=eog_idx + muscle_idx)
+
+    # make forward model
+    fwd = mne.make_forward_solution(raw.info, trans=trans, src=src,
+                                    bem=bem, eeg=True, mindist=5.0)
+
+    rank = mne.compute_rank(epochs, tol=1e-6, tol_kind='relative')
+
+    # compute cross-spectral density matrices
+    freqs = np.logspace(np.log10(12), np.log10(30), 9)
+
+    # time-frequency decomposition
+    epochs_tfr = mne.time_frequency.tfr_morlet(
+        epochs, freqs=freqs, n_cycles=freqs / 2, return_itc=False,
+        average=False, output='complex')
+
+    baseline_csd = csd_tfr(
+        epochs_tfr, tmin=baseline_win[0], tmax=baseline_win[1])
+
+    epochs_tfr.decimate(20)  # decimate for speed
+    insts_tfr.append(epochs_tfr)
+
+    # Compute source estimate using MNE solver
+    snr = 3.0
+    lambda2 = 1.0 / snr ** 2
+    method = 'MNE'  # use MNE method (could also be dSPM or sLORETA)
+
+    epochs.decimate(20)
+    insts_epochs.append(epochs)
+
+    # do time-series epochs first
+    baseline_cov = mne.compute_covariance(epochs, tmax=0)
+    inverse_operator = mne.minimum_norm.make_inverse_operator(
+        epochs.info, fwd, baseline_cov)
+    stcs_epochs.append(mne.minimum_norm.apply_inverse_epochs(
+        epochs, inverse_operator, lambda2, method=method,
+        pick_ori='vector', return_generator=True))
+
+    # make a different inverse operator for each frequency so as to properly
+    # whiten the sensor data
+    stcs = list()
+    for freq_idx in range(epochs_tfr.freqs.size):
+        # for each frequency, compute a separate covariance matrix
+        baseline_cov = baseline_csd.get_data(index=freq_idx, as_cov=True)
+        # only normalize by real
+        baseline_cov['data'] = baseline_cov['data'].real
+        # then use that covariance matrix as normalization for the inverse
+        # operator
+        inverse_operator = mne.minimum_norm.make_inverse_operator(
+            epochs.info, fwd, baseline_cov)
+
+    # finally, compute the stcs for each epoch and frequency
+    stcs = mne.minimum_norm.apply_inverse_tfr_epochs(
+        epochs_tfr, inverse_operator, lambda2, method=method,
+        pick_ori='vector', return_generator=True)
+
+    # append to group
+    stcs_tfr.append(stcs)
+
+# %%
+# Use the viewer to explore the time-course source estimates.
+
+viewer = mne_gui.view_vol_stc(stcs_epochs, group=True, freq_first=False,
+                              subject=template, subjects_dir=subjects_dir,
+                              src=src, inst=insts_epochs, tmin=tmin, tmax=tmax)
+viewer.go_to_extreme()  # show the maximum intensity source vertex
+viewer.set_cmap(vmin=0.25, vmid=0.8)
+viewer.set_3d_view(azimuth=40, elevation=35, distance=300)
+
+# %%
+# Use the viewer to explore the time-frequency source estimates, specifically
+# inter-trial coherence (itc).
+
+viewer = mne_gui.view_vol_stc(stcs_tfr, group='itc',
+                              subject=template, subjects_dir=subjects_dir,
+                              src=src, inst=insts_tfr, tmin=tmin, tmax=tmax)
+viewer.go_to_extreme()  # show the maximum intensity source vertex
+viewer.set_cmap(vmin=0.25, vmid=0.8)
+viewer.set_3d_view(azimuth=40, elevation=35, distance=300)

--- a/examples/volume_stc_group_study.py
+++ b/examples/volume_stc_group_study.py
@@ -1,11 +1,12 @@
 """
-.. _ex-ieeg-micro:
+.. _ex-vol-stc-group:
 
 ====================================================
 Volume Source Time Course Estimate for a Group Study
 ====================================================
 
-
+In this example, we'll show how to use the MNE volume stc viewing
+GUI to compare brain activity across subjects in a group study.
 """
 
 # Authors: Alex Rockhill <aprockhill@mailbox.org>

--- a/examples/volume_stc_group_study.py
+++ b/examples/volume_stc_group_study.py
@@ -47,7 +47,7 @@ insts_tfr = list()
 insts_epochs = list()
 for sub in range(1, 4):
     print(f"Computing source estimate for subject {sub}")
-    raw_fnames = mne.datasets.eegbci.load_data(subject=sub, runs=runs)
+    raw_fnames = mne.datasets.eegbci.load_data(subject=sub, runs=runs, update_path=True)
     raw = mne.concatenate_raws(
         [
             mne.io.read_raw(raw_fname, preload=True, verbose=False)

--- a/examples/volume_stc_group_study.py
+++ b/examples/volume_stc_group_study.py
@@ -22,15 +22,15 @@ from mne.time_frequency import csd_tfr
 fs_dir = mne.datasets.fetch_fsaverage(verbose=True)
 subjects_dir = op.dirname(fs_dir)
 
-template = 'fsaverage'
-trans = 'fsaverage'  # MNE has a built-in fsaverage transformation
-src = mne.read_source_spaces(
-    op.join(fs_dir, 'bem', 'fsaverage-vol-5-src.fif'))
+template = "fsaverage"
+trans = "fsaverage"  # MNE has a built-in fsaverage transformation
+src = mne.read_source_spaces(op.join(fs_dir, "bem", "fsaverage-vol-5-src.fif"))
 bem = mne.read_bem_solution(
-    op.join(fs_dir, 'bem', 'fsaverage-5120-5120-5120-bem-sol.fif'))
+    op.join(fs_dir, "bem", "fsaverage-5120-5120-5120-bem-sol.fif")
+)
 
 # basic task parameters
-tmin, tmax = -1., 4.
+tmin, tmax = -1.0, 4.0
 active_win = (0, 4)
 baseline_win = (-1, 0)
 event_id = dict(hands=2, feet=3)
@@ -40,27 +40,40 @@ runs = [6, 10, 14]  # motor imagery: hands vs feet
 # Compute source time course (stc) estimates for both time courses
 # and spectrograms (time-frequency).
 
-montage = mne.channels.make_standard_montage('standard_1005')
+montage = mne.channels.make_standard_montage("standard_1005")
 stcs_tfr = list()
 stcs_epochs = list()
 insts_tfr = list()
 insts_epochs = list()
 for sub in range(1, 4):
-    print(f'Computing source estimate for subject {sub}')
+    print(f"Computing source estimate for subject {sub}")
     raw_fnames = mne.datasets.eegbci.load_data(subject=sub, runs=runs)
-    raw = mne.concatenate_raws([
-        mne.io.read_raw(raw_fname, preload=True, verbose=False)
-        for raw_fname in raw_fnames])
+    raw = mne.concatenate_raws(
+        [
+            mne.io.read_raw(raw_fname, preload=True, verbose=False)
+            for raw_fname in raw_fnames
+        ]
+    )
     mne.datasets.eegbci.standardize(raw)  # set channel names
     raw.set_montage(montage, verbose=False)
 
     # make epochs
     events, _ = mne.events_from_annotations(raw, event_id=dict(T1=2, T2=3))
 
-    picks = mne.pick_types(raw.info, meg=False, eeg=True, stim=False,
-                           eog=False, exclude='bads')
-    epochs = mne.Epochs(raw, events, event_id, tmin - 0.5, tmax + 0.5,
-                        proj=True, picks=picks, baseline=None, preload=True)
+    picks = mne.pick_types(
+        raw.info, meg=False, eeg=True, stim=False, eog=False, exclude="bads"
+    )
+    epochs = mne.Epochs(
+        raw,
+        events,
+        event_id,
+        tmin - 0.5,
+        tmax + 0.5,
+        proj=True,
+        picks=picks,
+        baseline=None,
+        preload=True,
+    )
     epochs.set_eeg_reference(projection=True)
 
     # reject bad epochs
@@ -71,34 +84,39 @@ for sub in range(1, 4):
     ica = mne.preprocessing.ICA(n_components=15, random_state=11)
     ica.fit(epochs)
 
-    eog_idx, scores = ica.find_bads_eog(epochs, ch_name='Fp1')
+    eog_idx, scores = ica.find_bads_eog(epochs, ch_name="Fp1")
     muscle_idx, scores = ica.find_bads_muscle(epochs)
     ica.apply(epochs, exclude=eog_idx + muscle_idx)
 
     # make forward model
-    fwd = mne.make_forward_solution(raw.info, trans=trans, src=src,
-                                    bem=bem, eeg=True, mindist=5.0)
+    fwd = mne.make_forward_solution(
+        raw.info, trans=trans, src=src, bem=bem, eeg=True, mindist=5.0
+    )
 
-    rank = mne.compute_rank(epochs, tol=1e-6, tol_kind='relative')
+    rank = mne.compute_rank(epochs, tol=1e-6, tol_kind="relative")
 
     # compute cross-spectral density matrices
     freqs = np.logspace(np.log10(12), np.log10(30), 9)
 
     # time-frequency decomposition
     epochs_tfr = mne.time_frequency.tfr_morlet(
-        epochs, freqs=freqs, n_cycles=freqs / 2, return_itc=False,
-        average=False, output='complex')
+        epochs,
+        freqs=freqs,
+        n_cycles=freqs / 2,
+        return_itc=False,
+        average=False,
+        output="complex",
+    )
 
-    baseline_csd = csd_tfr(
-        epochs_tfr, tmin=baseline_win[0], tmax=baseline_win[1])
+    baseline_csd = csd_tfr(epochs_tfr, tmin=baseline_win[0], tmax=baseline_win[1])
 
     epochs_tfr.decimate(20)  # decimate for speed
     insts_tfr.append(epochs_tfr)
 
     # Compute source estimate using MNE solver
     snr = 3.0
-    lambda2 = 1.0 / snr ** 2
-    method = 'MNE'  # use MNE method (could also be dSPM or sLORETA)
+    lambda2 = 1.0 / snr**2
+    method = "MNE"  # use MNE method (could also be dSPM or sLORETA)
 
     epochs.decimate(20)
     insts_epochs.append(epochs)
@@ -106,10 +124,18 @@ for sub in range(1, 4):
     # do time-series epochs first
     baseline_cov = mne.compute_covariance(epochs, tmax=0)
     inverse_operator = mne.minimum_norm.make_inverse_operator(
-        epochs.info, fwd, baseline_cov)
-    stcs_epochs.append(mne.minimum_norm.apply_inverse_epochs(
-        epochs, inverse_operator, lambda2, method=method,
-        pick_ori='vector', return_generator=True))
+        epochs.info, fwd, baseline_cov
+    )
+    stcs_epochs.append(
+        mne.minimum_norm.apply_inverse_epochs(
+            epochs,
+            inverse_operator,
+            lambda2,
+            method=method,
+            pick_ori="vector",
+            return_generator=True,
+        )
+    )
 
     # make a different inverse operator for each frequency so as to properly
     # whiten the sensor data
@@ -118,16 +144,22 @@ for sub in range(1, 4):
         # for each frequency, compute a separate covariance matrix
         baseline_cov = baseline_csd.get_data(index=freq_idx, as_cov=True)
         # only normalize by real
-        baseline_cov['data'] = baseline_cov['data'].real
+        baseline_cov["data"] = baseline_cov["data"].real
         # then use that covariance matrix as normalization for the inverse
         # operator
         inverse_operator = mne.minimum_norm.make_inverse_operator(
-            epochs.info, fwd, baseline_cov)
+            epochs.info, fwd, baseline_cov
+        )
 
     # finally, compute the stcs for each epoch and frequency
     stcs = mne.minimum_norm.apply_inverse_tfr_epochs(
-        epochs_tfr, inverse_operator, lambda2, method=method,
-        pick_ori='vector', return_generator=True)
+        epochs_tfr,
+        inverse_operator,
+        lambda2,
+        method=method,
+        pick_ori="vector",
+        return_generator=True,
+    )
 
     # append to group
     stcs_tfr.append(stcs)
@@ -135,9 +167,17 @@ for sub in range(1, 4):
 # %%
 # Use the viewer to explore the time-course source estimates.
 
-viewer = mne_gui.view_vol_stc(stcs_epochs, group=True, freq_first=False,
-                              subject=template, subjects_dir=subjects_dir,
-                              src=src, inst=insts_epochs, tmin=tmin, tmax=tmax)
+viewer = mne_gui.view_vol_stc(
+    stcs_epochs,
+    group=True,
+    freq_first=False,
+    subject=template,
+    subjects_dir=subjects_dir,
+    src=src,
+    inst=insts_epochs,
+    tmin=tmin,
+    tmax=tmax,
+)
 viewer.go_to_extreme()  # show the maximum intensity source vertex
 viewer.set_cmap(vmin=0.25, vmid=0.8)
 viewer.set_3d_view(azimuth=40, elevation=35, distance=300)
@@ -146,9 +186,16 @@ viewer.set_3d_view(azimuth=40, elevation=35, distance=300)
 # Use the viewer to explore the time-frequency source estimates, specifically
 # inter-trial coherence (itc).
 
-viewer = mne_gui.view_vol_stc(stcs_tfr, group='itc',
-                              subject=template, subjects_dir=subjects_dir,
-                              src=src, inst=insts_tfr, tmin=tmin, tmax=tmax)
+viewer = mne_gui.view_vol_stc(
+    stcs_tfr,
+    group="itc",
+    subject=template,
+    subjects_dir=subjects_dir,
+    src=src,
+    inst=insts_tfr,
+    tmin=tmin,
+    tmax=tmax,
+)
 viewer.go_to_extreme()  # show the maximum intensity source vertex
 viewer.set_cmap(vmin=0.25, vmid=0.8)
 viewer.set_3d_view(azimuth=40, elevation=35, distance=300)

--- a/mne_gui_addons/_vol_stc.py
+++ b/mne_gui_addons/_vol_stc.py
@@ -266,9 +266,7 @@ class VolSourceEstimateViewer(SliceBrowser):
             self._inst.freqs.size // 2 if hasattr(self._inst, "freqs") else None
         )
         self._alpha = 0.75
-        self._epoch_idx = (
-            "Average" + " Power" * (self._is_complex and not self._group)
-        )
+        self._epoch_idx = "Average" + " Power" * (self._is_complex and not self._group)
 
         # initialize current 3D image for chosen time and frequency
         stc_data = self._pick_epoch(self._data)
@@ -847,11 +845,15 @@ class VolSourceEstimateViewer(SliceBrowser):
 
         if self._group:
             if self._epoch_idx == "Average":
-                inst_data = np.concatenate([get_inst_data(inst)
-                                            for inst in self._insts], axis=0)
+                inst_data = np.concatenate(
+                    [get_inst_data(inst) for inst in self._insts], axis=0
+                )
             else:
                 inst_data = get_inst_data(
-                    self._insts[int(self._epoch_idx.replace(f"{self._selector_prefix} ", ""))])
+                    self._insts[
+                        int(self._epoch_idx.replace(f"{self._selector_prefix} ", ""))
+                    ]
+                )
         else:
             inst_data = get_inst_data(self._inst)
 

--- a/mne_gui_addons/_vol_stc.py
+++ b/mne_gui_addons/_vol_stc.py
@@ -144,8 +144,7 @@ class VolSourceEstimateViewer(SliceBrowser):
             averaged across epochs and ``n_freqs`` may be 1 for data
             that is in time only and is not time-frequency decomposed. For
             faster performance, data can be cast to integers or a
-            custom complex data type that uses integers as done by
-            :func:`mne.gui.view_vol_stc`.
+            custom complex data type that uses integers.
         %(subject)s
         %(subjects_dir)s
         src : instance of SourceSpaces

--- a/mne_gui_addons/tests/test_core.py
+++ b/mne_gui_addons/tests/test_core.py
@@ -21,7 +21,7 @@ subjects_dir = data_path / "subjects"
 def test_slice_browser_io(renderer_interactive_pyvistaqt):
     """Test the input/output of the slice browser GUI."""
     nib = pytest.importorskip("nibabel")
-    from mne.gui._core import SliceBrowser
+    from mne_gui_addons._core import SliceBrowser
 
     with pytest.raises(ValueError, match="Base image is not aligned to MRI"):
         SliceBrowser(
@@ -37,7 +37,7 @@ def test_slice_browser_io(renderer_interactive_pyvistaqt):
 def test_slice_browser_display(renderer_interactive_pyvistaqt):
     """Test that the slice browser GUI displays properly."""
     pytest.importorskip("nibabel")
-    from mne.gui._core import SliceBrowser
+    from mne_gui_addons._core import SliceBrowser
 
     # test no seghead, fsaverage doesn't have seghead
     with pytest.warns(RuntimeWarning, match="`seghead` not found"):

--- a/mne_gui_addons/tests/test_ieeg_locate.py
+++ b/mne_gui_addons/tests/test_ieeg_locate.py
@@ -102,7 +102,7 @@ def test_locate_scraper(renderer_interactive_pyvistaqt, _fake_CT_coords, tmp_pat
         "EEG 003": "LSTN 1",
         "EEG 004": "LSTN 2",
     }
-    raw.pick_channels(list(ch_dict.keys()))
+    raw.pick(list(ch_dict.keys()))
     raw.rename_channels(ch_dict)
     raw.set_montage(None)
     aligned_ct, _ = _fake_CT_coords
@@ -137,7 +137,7 @@ def test_ieeg_elec_locate_display(renderer_interactive_pyvistaqt, _fake_CT_coord
         "EEG 003": "LSTN 1",
         "EEG 004": "LSTN 2",
     }
-    raw.pick_channels(list(ch_dict.keys()))
+    raw.pick(list(ch_dict.keys()))
     raw.rename_channels(ch_dict)
     raw.set_eeg_reference("average")
     raw.set_channel_types({name: "seeg" for name in raw.ch_names})

--- a/mne_gui_addons/tests/test_ieeg_locate.py
+++ b/mne_gui_addons/tests/test_ieeg_locate.py
@@ -13,6 +13,7 @@ from mne.datasets import testing
 from mne.transforms import apply_trans
 from mne.utils import requires_version, use_log_level
 from mne.viz.utils import _fake_click
+import mne_gui_addons as mne_gui
 
 data_path = testing.data_path(download=False)
 subject = "sample"
@@ -67,7 +68,6 @@ def _fake_CT_coords(skull_size=5, contact_size=2):
 def test_ieeg_elec_locate_io(renderer_interactive_pyvistaqt):
     """Test the input/output of the intracranial location GUI."""
     nib = pytest.importorskip("nibabel")
-    import mne.gui
 
     info = mne.create_info([], 1000)
 
@@ -76,7 +76,7 @@ def test_ieeg_elec_locate_io(renderer_interactive_pyvistaqt):
 
     trans = mne.transforms.Transform("head", "mri")
     with pytest.raises(ValueError, match="No channels found in `info` to locate"):
-        mne.gui.locate_ieeg(info, trans, aligned_ct, subject, subjects_dir)
+        mne_gui.locate_ieeg(info, trans, aligned_ct, subject, subjects_dir)
 
     info = mne.create_info(["test"], 1000, "seeg")
     montage = mne.channels.make_dig_montage({"test": [0, 0, 0]}, coord_frame="mri")
@@ -84,7 +84,7 @@ def test_ieeg_elec_locate_io(renderer_interactive_pyvistaqt):
         info.set_montage(montage)
     with pytest.raises(RuntimeError, match='must be in the "head" coordinate frame'):
         with pytest.warns(RuntimeWarning, match="`pial` surface not found"):
-            mne.gui.locate_ieeg(info, trans, aligned_ct, subject, subjects_dir)
+            mne_gui.locate_ieeg(info, trans, aligned_ct, subject, subjects_dir)
 
 
 @pytest.mark.allow_unclosed_pyside2
@@ -92,8 +92,6 @@ def test_ieeg_elec_locate_io(renderer_interactive_pyvistaqt):
 @testing.requires_testing_data
 def test_locate_scraper(renderer_interactive_pyvistaqt, _fake_CT_coords, tmp_path):
     """Test sphinx-gallery scraping of the GUI."""
-    import mne.gui
-
     raw = mne.io.read_raw_fif(raw_path)
     raw.pick_types(eeg=True)
     ch_dict = {
@@ -108,7 +106,7 @@ def test_locate_scraper(renderer_interactive_pyvistaqt, _fake_CT_coords, tmp_pat
     aligned_ct, _ = _fake_CT_coords
     trans = mne.read_trans(fname_trans)
     with pytest.warns(RuntimeWarning, match="`pial` surface not found"):
-        gui = mne.gui.locate_ieeg(
+        gui = mne_gui.locate_ieeg(
             raw.info, trans, aligned_ct, subject=subject, subjects_dir=subjects_dir
         )
     (tmp_path / "_images").mkdir()
@@ -119,7 +117,7 @@ def test_locate_scraper(renderer_interactive_pyvistaqt, _fake_CT_coords, tmp_pat
     )
     assert not image_path.is_file()
     assert not getattr(gui, "_scraped", False)
-    mne.gui._GUIScraper()(None, block_vars, gallery_conf)
+    mne_gui._GUIScraper()(None, block_vars, gallery_conf)
     assert image_path.is_file()
     assert gui._scraped
     # no need to call .close
@@ -146,7 +144,7 @@ def test_ieeg_elec_locate_display(renderer_interactive_pyvistaqt, _fake_CT_coord
     trans = mne.read_trans(fname_trans)
 
     with pytest.warns(RuntimeWarning, match="`pial` surface not found"):
-        gui = mne.gui.locate_ieeg(
+        gui = mne_gui.locate_ieeg(
             raw.info,
             trans,
             aligned_ct,


### PR DESCRIPTION
Adds the ability to see the average at a group level:

```
import os.path as op
import numpy as np
import mne
import mne_gui_addons as mne_gui
import autoreject
from mne.time_frequency import csd_tfr

fs_dir = mne.datasets.fetch_fsaverage(verbose=True)
subjects_dir = op.dirname(fs_dir)

template = 'fsaverage'
trans = 'fsaverage'  # MNE has a built-in fsaverage transformation
src = mne.read_source_spaces(
    op.join(fs_dir, 'bem', 'fsaverage-vol-5-src.fif'))
bem = mne.read_bem_solution(
    op.join(fs_dir, 'bem', 'fsaverage-5120-5120-5120-bem-sol.fif'))

# avoid classification of evoked responses by using epochs that start 1s after
# cue onset.
tmin, tmax = -1., 4.
active_win = (0, 4)
baseline_win = (-1, 0)
event_id = dict(hands=2, feet=3)
runs = [6, 10, 14]  # motor imagery: hands vs feet

montage = mne.channels.make_standard_montage('standard_1005')
stcs_tfr = list()
stcs_epochs = list()
insts_tfr = list()
insts_epochs = list()
for sub in range(1, 11):
    print(f'Computing source estimate for subject {sub}')
    raw_fnames = mne.datasets.eegbci.load_data(subject=sub, runs=runs)
    raw = mne.concatenate_raws([
        mne.io.read_raw(raw_fname, preload=True, verbose=False)
        for raw_fname in raw_fnames])
    mne.datasets.eegbci.standardize(raw)  # set channel names
    raw.set_montage(montage, verbose=False)

    # make epochs
    events, _ = mne.events_from_annotations(raw, event_id=dict(T1=2, T2=3))

    picks = mne.pick_types(raw.info, meg=False, eeg=True, stim=False,
                           eog=False, exclude='bads')
    epochs = mne.Epochs(raw, events, event_id, tmin - 0.5, tmax + 0.5,
                        proj=True, picks=picks, baseline=None, preload=True)
    epochs.set_eeg_reference(projection=True)

    # reject bad epochs
    reject = autoreject.get_rejection_threshold(epochs)
    epochs.drop_bad(reject=reject)

    epochs.filter(l_freq=1, h_freq=None)
    ica = mne.preprocessing.ICA(n_components=15, random_state=11)
    ica.fit(epochs)

    eog_idx, scores = ica.find_bads_eog(epochs, ch_name='Fp1')
    muscle_idx, scores = ica.find_bads_muscle(epochs)
    ica.apply(epochs, exclude=eog_idx + muscle_idx)

    # make forward model
    fwd = mne.make_forward_solution(raw.info, trans=trans, src=src,
                                    bem=bem, eeg=True, mindist=5.0)

    rank = mne.compute_rank(epochs, tol=1e-6, tol_kind='relative')

    # compute cross-spectral density matrices
    freqs = np.logspace(np.log10(12), np.log10(30), 9)

    # time-frequency decomposition
    epochs_tfr = mne.time_frequency.tfr_morlet(
        epochs, freqs=freqs, n_cycles=freqs / 2, return_itc=False,
        average=False, output='complex')

    baseline_csd = csd_tfr(
        epochs_tfr, tmin=baseline_win[0], tmax=baseline_win[1])

    epochs_tfr.decimate(20)  # decimate for speed
    insts_tfr.append(epochs_tfr)

    # Compute source estimate using MNE solver
    snr = 3.0
    lambda2 = 1.0 / snr ** 2
    method = 'MNE'  # use MNE method (could also be dSPM or sLORETA)

    epochs.decimate(20)
    insts_epochs.append(epochs)

    # do time-series epochs first
    baseline_cov = mne.compute_covariance(epochs, tmax=0)
    inverse_operator = mne.minimum_norm.make_inverse_operator(
        epochs.info, fwd, baseline_cov)
    stcs_epochs.append(mne.minimum_norm.apply_inverse_epochs(
        epochs, inverse_operator, lambda2, method=method,
        pick_ori='vector', return_generator=True))

    # make a different inverse operator for each frequency so as to properly
    # whiten the sensor data
    stcs = list()
    for freq_idx in range(epochs_tfr.freqs.size):
        # for each frequency, compute a separate covariance matrix
        baseline_cov = baseline_csd.get_data(index=freq_idx, as_cov=True)
        # only normalize by real
        baseline_cov['data'] = baseline_cov['data'].real
        # then use that covariance matrix as normalization for the inverse
        # operator
        inverse_operator = mne.minimum_norm.make_inverse_operator(
            epochs.info, fwd, baseline_cov)

    # finally, compute the stcs for each epoch and frequency
    stcs = mne.minimum_norm.apply_inverse_tfr_epochs(
        epochs_tfr, inverse_operator, lambda2, method=method,
        pick_ori='vector', return_generator=True)

    # append to group
    stcs_tfr.append(stcs)

viewer = mne_gui.view_vol_stc(stcs_epochs, group=True, freq_first=False,
                              subject=template, subjects_dir=subjects_dir,
                              src=src, inst=insts_epochs, tmin=tmin, tmax=tmax)
viewer.go_to_extreme()  # show the maximum intensity source vertex
viewer.set_cmap(vmin=0.25, vmid=0.8)
viewer.set_3d_view(azimuth=40, elevation=35, distance=300)


viewer = mne_gui.view_vol_stc(stcs_tfr, group='itc',
                              subject=template, subjects_dir=subjects_dir,
                              src=src, inst=insts_tfr, tmin=tmin, tmax=tmax)
viewer.go_to_extreme()  # show the maximum intensity source vertex
viewer.set_cmap(vmin=0.25, vmid=0.8)
viewer.set_3d_view(azimuth=40, elevation=35, distance=300)
```