### PR TITLE
[BUG, MRG] Fix no more dimensions transposed

### DIFF
--- a/mne_gui_addons/_core.py
+++ b/mne_gui_addons/_core.py
@@ -330,8 +330,7 @@ class SliceBrowser(QMainWindow):
                 np.where(self._base_data < np.quantile(self._base_data, 0.95), 0, 1),
                 [1],
             )[0]
-            # marching cubes transposes dimensions so flip
-            rr = apply_trans(self._vox_ras_t, rr[:, ::-1])
+            rr = apply_trans(self._vox_ras_t, rr)
             self._renderer.mesh(
                 *rr.T,
                 triangles=tris,


### PR DESCRIPTION
This fixes the dimensions not needing to be fixed anymore after the fortran ordering array bug fix on `mne-python` for marching cubes.