### PR TITLE
[ENH] More natural zoom

### DIFF
--- a/mne_gui_addons/_core.py
+++ b/mne_gui_addons/_core.py
@@ -413,7 +413,7 @@ class SliceBrowser(QMainWindow):
 
     def _zoom(self, sign=1, draw=False):
         """Zoom in on the image."""
-        delta = _ZOOM_STEP_SIZE * sign
+        delta = _ZOOM_STEP_SIZE * -(sign < 0)  # negative if zooming out
         for axis, fig in enumerate(self._figs):
             xcur = self._images["cursor_v"][axis].get_xdata()[0]
             ycur = self._images["cursor_h"][axis].get_ydata()[0]
@@ -422,11 +422,16 @@ class SliceBrowser(QMainWindow):
             ymin, ymax = fig.axes[0].get_ylim()
             xmid = (xmin + xmax) / 2
             ymid = (ymin + ymax) / 2
-            if sign == 1:  # may need to shift if zooming in
+            if sign >= 0:  # may need to shift if zooming in or clicking
                 if abs(xmid - xcur) > delta / 2 * rx:
                     xmid += delta * np.sign(xcur - xmid) * rx
+                if xcur < xmin or xcur > xmax:  # out of view, reset
+                    xmid = xcur
                 if abs(ymid - ycur) > delta / 2 * ry:
                     ymid += delta * np.sign(ycur - ymid) * ry
+                if ycur < ymin or ycur > ymax:  # out of view, reset
+                    ymid = ycur
+
             xwidth = (xmax - xmin) / 2 - delta * rx
             ywidth = (ymax - ymin) / 2 - delta * ry
             if xwidth <= 0 or ywidth <= 0:
@@ -613,6 +618,7 @@ class SliceBrowser(QMainWindow):
         """Move to view on MRI and CT on click."""
         if event.inaxes is self._figs[axis].axes[0]:
             # Data coordinates are voxel coordinates
+            print(event, axis)
             pos = (event.xdata, event.ydata)
             logger.debug(f'Clicked {"XYZ"[axis]} ({axis}) axis at pos {pos}')
             xyz = self._vox
@@ -620,6 +626,7 @@ class SliceBrowser(QMainWindow):
             logger.debug(f"Using voxel  {list(xyz)}")
             ras = apply_trans(self._vox_ras_t, xyz)
             self._set_ras(ras)
+            self._zoom(sign=0, draw=True)
 
     def _update_moved(self):
         """Update when cursor position changes."""

--- a/mne_gui_addons/_core.py
+++ b/mne_gui_addons/_core.py
@@ -413,7 +413,7 @@ class SliceBrowser(QMainWindow):
 
     def _zoom(self, sign=1, draw=False):
         """Zoom in on the image."""
-        delta = _ZOOM_STEP_SIZE * -(sign < 0)  # negative if zooming out
+        delta = _ZOOM_STEP_SIZE * sign
         for axis, fig in enumerate(self._figs):
             xcur = self._images["cursor_v"][axis].get_xdata()[0]
             ycur = self._images["cursor_h"][axis].get_ydata()[0]
@@ -423,12 +423,12 @@ class SliceBrowser(QMainWindow):
             xmid = (xmin + xmax) / 2
             ymid = (ymin + ymax) / 2
             if sign >= 0:  # may need to shift if zooming in or clicking
-                if abs(xmid - xcur) > delta / 2 * rx:
-                    xmid += delta * np.sign(xcur - xmid) * rx
+                if min([xmax - xcur, xcur - xmin]) < (xmax - xmin) / 3:
+                    xmid += (xcur - xmid) / 6
                 if xcur < xmin or xcur > xmax:  # out of view, reset
                     xmid = xcur
-                if abs(ymid - ycur) > delta / 2 * ry:
-                    ymid += delta * np.sign(ycur - ymid) * ry
+                if min([ymax - ycur, ycur - ymin]) < (ymax - ymin) / 3:
+                    ymid += (ycur - ymid) / 6
                 if ycur < ymin or ycur > ymax:  # out of view, reset
                     ymid = ycur
 
@@ -618,7 +618,6 @@ class SliceBrowser(QMainWindow):
         """Move to view on MRI and CT on click."""
         if event.inaxes is self._figs[axis].axes[0]:
             # Data coordinates are voxel coordinates
-            print(event, axis)
             pos = (event.xdata, event.ydata)
             logger.debug(f'Clicked {"XYZ"[axis]} ({axis}) axis at pos {pos}')
             xyz = self._vox

--- a/mne_gui_addons/_core.py
+++ b/mne_gui_addons/_core.py
@@ -423,12 +423,14 @@ class SliceBrowser(QMainWindow):
             xmid = (xmin + xmax) / 2
             ymid = (ymin + ymax) / 2
             if sign >= 0:  # may need to shift if zooming in or clicking
-                if min([xmax - xcur, xcur - xmin]) < (xmax - xmin) / 3:
-                    xmid += (xcur - xmid) / 6
+                xedge = min([xmax - xcur, xcur - xmin])
+                if xedge < (xmax - xmin) / 3:
+                    xmid += np.sign(xcur - xmid) * ((xmax - xmin) / 3 - xedge)
                 if xcur < xmin or xcur > xmax:  # out of view, reset
                     xmid = xcur
-                if min([ymax - ycur, ycur - ymin]) < (ymax - ymin) / 3:
-                    ymid += (ycur - ymid) / 6
+                yedge = min([ymax - ycur, ycur - ymin])
+                if yedge < (ymax - ymin) / 3:
+                    ymid += np.sign(ycur - ymid) * ((ymax - ymin) / 3 - yedge)
                 if ycur < ymin or ycur > ymax:  # out of view, reset
                     ymid = ycur
 

--- a/mne_gui_addons/_core.py
+++ b/mne_gui_addons/_core.py
@@ -426,12 +426,16 @@ class SliceBrowser(QMainWindow):
             if sign >= 0:  # may need to shift if zooming in or clicking
                 xedge = min([xmax - xcur, xcur - xmin])
                 if xedge < (xmax - xmin) * _ZOOM_BORDER:
-                    xmid += np.sign(xcur - xmid) * ((xmax - xmin) * _ZOOM_BORDER - xedge)
+                    xmid += np.sign(xcur - xmid) * (
+                        (xmax - xmin) * _ZOOM_BORDER - xedge
+                    )
                 if xcur < xmin or xcur > xmax:  # out of view, reset
                     xmid = xcur
                 yedge = min([ymax - ycur, ycur - ymin])
                 if yedge < (ymax - ymin) * _ZOOM_BORDER:
-                    ymid += np.sign(ycur - ymid) * ((ymax - ymin) * _ZOOM_BORDER - yedge)
+                    ymid += np.sign(ycur - ymid) * (
+                        (ymax - ymin) * _ZOOM_BORDER - yedge
+                    )
                 if ycur < ymin or ycur > ymax:  # out of view, reset
                     ymid = ycur
 

--- a/mne_gui_addons/_core.py
+++ b/mne_gui_addons/_core.py
@@ -44,6 +44,7 @@ from mne.viz.backends._utils import _qt_safe_window
 
 _IMG_LABELS = [["I", "P"], ["I", "L"], ["P", "L"]]
 _ZOOM_STEP_SIZE = 5
+_ZOOM_BORDER = 1 / 5
 
 
 @verbose
@@ -424,13 +425,13 @@ class SliceBrowser(QMainWindow):
             ymid = (ymin + ymax) / 2
             if sign >= 0:  # may need to shift if zooming in or clicking
                 xedge = min([xmax - xcur, xcur - xmin])
-                if xedge < (xmax - xmin) / 3:
-                    xmid += np.sign(xcur - xmid) * ((xmax - xmin) / 3 - xedge)
+                if xedge < (xmax - xmin) * _ZOOM_BORDER:
+                    xmid += np.sign(xcur - xmid) * ((xmax - xmin) * _ZOOM_BORDER - xedge)
                 if xcur < xmin or xcur > xmax:  # out of view, reset
                     xmid = xcur
                 yedge = min([ymax - ycur, ycur - ymin])
-                if yedge < (ymax - ymin) / 3:
-                    ymid += np.sign(ycur - ymid) * ((ymax - ymin) / 3 - yedge)
+                if yedge < (ymax - ymin) * _ZOOM_BORDER:
+                    ymid += np.sign(ycur - ymid) * ((ymax - ymin) * _ZOOM_BORDER - yedge)
                 if ycur < ymin or ycur > ymax:  # out of view, reset
                     ymid = ycur
 

--- a/mne_gui_addons/_ieeg_locate.py
+++ b/mne_gui_addons/_ieeg_locate.py
@@ -553,8 +553,8 @@ class IntracranialElectrodeLocator(SliceBrowser):
         self._update_group()
         if not np.isnan(self._chs[name]).any():
             self._set_ras(self._chs[name])
+            self._zoom(sign=0, draw=True)
             self._update_camera(render=True)
-            self._draw()
 
     def _go_to_ch(self, index):
         """Change current channel to the item selected."""


### PR DESCRIPTION
There were two issues using the slice browser with the recent-ish zoom changes for the ieeg locator:

- When you clicked near the edge following the electrode shaft to label contacts, you had to zoom out and back in when you got to the edge of the plot in order to re-center which is annoying and unintuitive if you don't know how the code works
- When you jump to an already labeled electrode contact, it's completely out of view

Fixes:
- When the cursor gets to the outer 1 / 3, smooth recenter so that you can push the view by clicking but if you are clicking around the middle you don't get annoying recenters
- Jump to center when out of view (e.g, jump to already marked electrode or ras entry)

[Screencast from 11-11-2023 01:33:26 AM.webm](https://github.com/mne-tools/mne-gui-addons/assets/13473576/fa26f9a1-e421-479c-8442-cca3445edbc8)