### PR TITLE
[MAINT] ras->mri

### DIFF
--- a/mne_gui_addons/_ieeg_locate.py
+++ b/mne_gui_addons/_ieeg_locate.py
@@ -229,7 +229,7 @@ class IntracranialElectrodeLocator(SliceBrowser):
             if np.isnan(surf_ras).any():
                 continue
             xyz = apply_trans(
-                self._scan_ras_ras_vox_t, apply_trans(self._ras_scan_ras_t, surf_ras)
+                self._scan_ras_ras_vox_t, apply_trans(self._mri_scan_ras_t, surf_ras)
             )
             # check if closest to that voxel
             dist = np.linalg.norm(xyz - self._current_slice)
@@ -559,7 +559,7 @@ class IntracranialElectrodeLocator(SliceBrowser):
         self._group_selector.setCurrentIndex(self._groups[name])
         self._update_group()
         if not np.isnan(self._chs[name]).any():
-            self._set_ras(apply_trans(self._ras_scan_ras_t, self._chs[name]))
+            self._set_ras(apply_trans(self._mri_scan_ras_t, self._chs[name]))
             self._zoom(sign=0, draw=True)
             self._update_camera(render=True)
 

--- a/mne_gui_addons/_ieeg_locate.py
+++ b/mne_gui_addons/_ieeg_locate.py
@@ -142,7 +142,7 @@ class IntracranialElectrodeLocator(SliceBrowser):
         if not np.isnan(self._chs[self._ch_names[self._ch_index]]).any():
             self._set_ras(
                 apply_trans(
-                    self._ras_scan_ras_t, self._chs[self._ch_names[self._ch_index]]
+                    self._mri_scan_ras_t, self._chs[self._ch_names[self._ch_index]]
                 ),
                 update_plots=False,
             )
@@ -625,7 +625,7 @@ class IntracranialElectrodeLocator(SliceBrowser):
         ]
         if self._snap_button.text() == "Off":
             self._chs[name][:] = apply_trans(
-                self._scan_ras_ras_t, self._ras
+                self._scan_ras_mri_t, self._ras
             )  # stored as surface RAS
         else:
             shape = np.mean(self._voxel_sizes)  # Freesurfer shape (256)
@@ -640,7 +640,7 @@ class IntracranialElectrodeLocator(SliceBrowser):
                 use_relative=True,
             )
             self._chs[name][:] = apply_trans(  # to surface RAS
-                self._vox_ras_t, np.array(list(neighbors)).mean(axis=0)
+                self._vox_mri_t, np.array(list(neighbors)).mean(axis=0)
             )
         self._color_list_item()
         self._update_lines(self._groups[name])

--- a/mne_gui_addons/_ieeg_locate.py
+++ b/mne_gui_addons/_ieeg_locate.py
@@ -515,9 +515,15 @@ class IntracranialElectrodeLocator(SliceBrowser):
             )[0]
         if self._toggle_show_mip_button.text() == "Hide Max Intensity Proj":
             # add 2D lines on each slice plot if in max intensity projection
-            target_vox = apply_trans(self._ras_vox_t, pos[target_idx])
+            target_vox = apply_trans(
+                self._mri_scan_ras_t,
+                apply_trans(self._scan_ras_ras_vox_t, pos[target_idx]),
+            )
             insert_vox = apply_trans(
-                self._ras_vox_t, pos[insert_idx] + elec_v * _BOLT_SCALAR
+                self._mri_scan_ras_t,
+                apply_trans(
+                    self._scan_ras_ras_vox_t, pos[insert_idx] + elec_v * _BOLT_SCALAR
+                ),
             )
             lines_2D = list()
             for axis in range(3):

--- a/mne_gui_addons/_vol_stc.py
+++ b/mne_gui_addons/_vol_stc.py
@@ -349,8 +349,8 @@ class VolSourceEstimateViewer(SliceBrowser):
         # TO DO: add surface source space viewing as elif
         if any([this_src["type"] == "vol" for this_src in self._src]):
             scalars = np.array(np.where(np.isnan(self._stc_img), 0, 1.0))
-            spacing = np.diag(self._src_vox_ras_t)[:3]
-            origin = self._src_vox_ras_t[:3, 3] - spacing / 2.0
+            spacing = np.diag(self._src_vox_mri_t)[:3]
+            origin = self._src_vox_mri_t[:3, 3] - spacing / 2.0
             center = 0.5 * self._stc_range - self._stc_min
             (
                 self._grid,

--- a/mne_gui_addons/_vol_stc.py
+++ b/mne_gui_addons/_vol_stc.py
@@ -241,7 +241,7 @@ class VolSourceEstimateViewer(SliceBrowser):
         (
             self._src_lut,
             self._src_vox_scan_ras_t,
-            self._src_vox_ras_t,
+            self._src_vox_mri_t,
             self._src_rr,
         ) = _get_src_lut(src)
         self._src_scan_ras_vox_t = np.linalg.inv(self._src_vox_scan_ras_t)


### PR DESCRIPTION
Fixes internal nomenclature for coordinate systems, specifically surface RAS = `mri` and scanner RAS = `scan_ras`. I left that as opposed to just `ras` for extra clarity if that's okay. Can change it too.