### PR TITLE
Switch to mne-tools scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
         - run:
             name: Check Qt
             command: |
-              ./mne-tools/tools/check_qt_import.sh PyQt6
+               bash /mne-tools/tools/check_qt_import.sh PyQt6
         - run:
             name: Check installation
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
               set -e
               set -o pipefail
               git clone --single-branch --branch main git@github.com:/mne-tools/mne-python.git
-              ./mne-python/tools/setup_xvfb.sh
+              git clone --single-branch --branch main git@github.com:/mne-tools/mne-tools.git
+              ./mne-tools/tools/setup_xvfb.sh
               sudo apt install -qq graphviz optipng python3.10-venv python3-venv libxft2 ffmpeg
               python3.10 -m venv ~/python_env
               echo "set -e" >> $BASH_ENV
@@ -48,7 +49,7 @@ jobs:
         - run:
             name: Check Qt
             command: |
-              ./mne-python/tools/check_qt_import.sh PyQt6
+              ./mne-tools/tools/check_qt_import.sh PyQt6
         - run:
             name: Check installation
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
         - run:
             name: Check Qt
             command: |
-               bash /mne-tools/tools/check_qt_import.sh PyQt6
+               ./mne-tools/tools/check_qt_import.sh PyQt6
         - run:
             name: Check installation
             command: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,14 +60,9 @@ jobs:
     - run: pip install -v "${{ matrix.qt }}!=6.6.0,!=6.10.0" "PyQt6-Qt6!=6.6.0,!=6.7.0,!=6.10.0,!=6.10.1,!=6.10.2"
     - run: pip install -ve .[tests]
     - run: mne sys_info
-    - name: Get Python env root
-      shell: bash
-      run: |
-        echo "PYTHON_ENV_ROOT=$(python -c 'import pathlib, sys; print(pathlib.Path(sys.executable).resolve().parent.parent)')" >> "$GITHUB_ENV"
     - name: Check Qt import
       uses: tsbinns/mne-tools/actions/check-qt-import@tools-actions
       with:
-        python-env-root: ${{ env.PYTHON_ENV_ROOT }}
         qt-backend: ${{ matrix.qt }}
     - run: python -c "import mne_gui_addons; print(mne_gui_addons.__version__)"
     - run: ./tools/get_testing_version.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,9 @@ jobs:
     - run: pip install -ve .[tests]
     - run: mne sys_info
     - name: Get Python env root
-      run: echo "PYTHON_ENV_ROOT=$(dirname $(dirname $(which python)))" | tee -a $GITHUB_ENV
+      shell: bash
+      run: |
+        echo "PYTHON_ENV_ROOT=$(python -c 'import pathlib, sys; print(pathlib.Path(sys.executable).resolve().parent.parent)')" >> "$GITHUB_ENV"
     - name: Check Qt import
       uses: tsbinns/mne-tools/actions/check-qt-import@tools-actions
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,13 +60,13 @@ jobs:
     - run: pip install -v "${{ matrix.qt }}!=6.6.0,!=6.10.0" "PyQt6-Qt6!=6.6.0,!=6.7.0,!=6.10.0,!=6.10.1,!=6.10.2"
     - run: pip install -ve .[tests]
     - run: mne sys_info
-    # Check Qt
-    - run: |
-        wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/check_qt_import.sh
-        bash check_qt_import.sh $MNE_QT_BACKEND
-      if: ${{ env.MNE_QT_BACKEND != '' }}
-      name: Check Qt
-      shell: bash
+    - name: Get Python env root
+      run: echo "PYTHON_ENV_ROOT=$(dirname $(dirname $(which python)))" | tee -a $GITHUB_ENV
+    - name: Check Qt import
+      uses: tsbinns/mne-tools/actions/check-qt-import@tools-actions
+      with:
+        python-env-root: ${{ env.PYTHON_ENV_ROOT }}
+        qt-backend: ${{ matrix.qt }}
     - run: python -c "import mne_gui_addons; print(mne_gui_addons.__version__)"
     - run: ./tools/get_testing_version.sh
       working-directory: mne-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,9 @@ jobs:
     - run: pip install -ve .[tests]
     - run: mne sys_info
     # Check Qt
-    - run: ./tools/check_qt_import.sh $MNE_QT_BACKEND
+    - run: |
+        wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/check_qt_import.sh
+        bash check_qt_import.sh $MNE_QT_BACKEND
       if: ${{ env.MNE_QT_BACKEND != '' }}
       name: Check Qt
       shell: bash


### PR DESCRIPTION
`setup_xvfb.sh` and `check_qt_import.sh` tools are being moved from MNE-Python (mne-tools/mne-python#13971) to MNE-Tools (https://github.com/mne-tools/mne-tools).

This PR makes it so the scripts are accessed in the CIs from their new home.