### PR TITLE
Add refleak as a test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ tests = [
     "black",  # function signature formatting
     "sphinx-gallery",
     "imageio-ffmpeg>=0.4.1",
+    "refleak >= 0.2.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Runs on `mne-main` are failing when setting up conftest due to refleak not being installed, e.g.: https://github.com/mne-tools/mne-gui-addons/actions/runs/29949103804/job/89022075228?pr=47